### PR TITLE
Update interface to satisfy torch.compile being goofy.

### DIFF
--- a/lightning_attn/ops/lightning_attn_interface.py
+++ b/lightning_attn/ops/lightning_attn_interface.py
@@ -42,12 +42,12 @@ def lightning_attn_func(q, k, v, s=None):
             end = arr[i + 1]
             q1 = q[..., start:end]
             k1 = k[..., start:end]
-            if s != None:
+            if s is not None:
                 o += lightning_attn2(q1, k1, v, s)
             else:
                 o += lightning_attn2_no_decay(q1, k1, v)
     else:
-        if s != None:
+        if s is not None:
             o = lightning_attn2(q, k, v, s)
         else:
             o = lightning_attn2_no_decay(q1, k1, v)


### PR DESCRIPTION
There's a strange edge case from torch compile that seems to not be happy with `s != None:` but is perfectly content with `s is not None:` so I've made the change to satisfy torch compile here. Simple alteration. 

Here's the error for reference:

```cpp
  File "/home/blackroot/.pyenv/versions/3.12.7/lib/python3.12/site-packages/torch/_dynamo/variables/builder.py", line 2333, in wrap_fx_proxy_cls
    unimplemented(
  File "/home/blackroot/.pyenv/versions/3.12.7/lib/python3.12/site-packages/torch/_dynamo/exc.py", line 297, in unimplemented
    raise Unsupported(msg, case_name=case_name)
torch._dynamo.exc.Unsupported: torch.* op returned non-Tensor bool call_function <built-in function ne>

from user code:
   File "/home/blackroot/Desktop/minimodels/lm lightning/models/model.py", line 44, in forward
    x = block(x)
  File "/home/blackroot/Desktop/minimodels/lm lightning/models/lightning_tensor_product.py", line 227, in forward
    x = self.learned_residual_scale_attn * x + self.attn(x)
  File "/home/blackroot/Desktop/minimodels/lm lightning/models/lightning_tensor_product.py", line 173, in forward
    attn_out = lightning_attn_func(
  File "/home/blackroot/.pyenv/versions/3.12.7/lib/python3.12/site-packages/lightning_attn/ops/lightning_attn_interface.py", line 50, in lightning_attn_func
    if s != None:
```

This might be an edge case inductor bug but I'll commit this fix on the offchance this is intended behaviour.

Reference torch compile settings:
```
    model = torch.compile(
        model,
        backend='inductor',
        dynamic=False,
        fullgraph=True,
        options={
            "epilogue_fusion": True,
            "max_autotune": True,
        }
    )
 ```
