### PR TITLE
Fix undeclared variables (`d <= 128`, `s is None` case) in lightning_attn_interface.py

### DIFF
--- a/lightning_attn/ops/lightning_attn_interface.py
+++ b/lightning_attn/ops/lightning_attn_interface.py
@@ -50,7 +50,7 @@ def lightning_attn_func(q, k, v, s=None):
         if s != None:
             o = lightning_attn2(q, k, v, s)
         else:
-            o = lightning_attn2_no_decay(q1, k1, v)
+            o = lightning_attn2_no_decay(q, k, v)
 
     if need_pad:
         o = o[:, :, :, :e]


### PR DESCRIPTION
Introduced in 0ae41be

The `q1, k1` inputs look like they were copied from the `if d > 128` case.